### PR TITLE
Implement Authentication

### DIFF
--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,1 +1,3 @@
 -r base.txt
+
+responses==0.5.1

--- a/verba/apps/auth/__init__.py
+++ b/verba/apps/auth/__init__.py
@@ -1,0 +1,107 @@
+from django.conf import settings
+from django.contrib.auth import load_backend
+from django.utils.crypto import constant_time_compare
+from django.contrib.auth.signals import user_logged_in, user_logged_out
+from django.middleware.csrf import rotate_token
+
+from .models import VerbaAnonymousUser, VerbaUser
+
+
+SESSION_KEY = '_auth_user_id'
+AUTH_TOKEN_SESSION_KEY = '_auth_user_auth_token'
+USER_DATA_SESSION_KEY = '_auth_user_data'
+BACKEND_SESSION_KEY = '_auth_user_backend'
+HASH_SESSION_KEY = '_auth_user_hash'
+
+
+def get_user_model():
+    return VerbaUser
+
+
+def update_token_in_session(request, token):
+    request.session[AUTH_TOKEN_SESSION_KEY] = token
+
+
+def login(request, user):
+    """
+    Persist a user id and a backend in the request. This way a user doesn't
+    have to reauthenticate on every request. Note that data set during
+    the anonymous session is retained when the user logs in.
+    """
+    session_auth_hash = ''
+    if user is None:
+        user = request.user
+    if hasattr(user, 'get_session_auth_hash'):
+        session_auth_hash = user.get_session_auth_hash()
+
+    if SESSION_KEY in request.session:
+        session_key = request.session[SESSION_KEY]
+        if session_key != user.pk or (
+                session_auth_hash and
+                request.session.get(HASH_SESSION_KEY) != session_auth_hash):
+            # To avoid reusing another user's session, create a new, empty
+            # session if the existing session corresponds to a different
+            # authenticated user.
+            request.session.flush()
+    else:
+        request.session.cycle_key()
+    request.session[SESSION_KEY] = user.pk
+    request.session[BACKEND_SESSION_KEY] = user.backend
+    request.session[USER_DATA_SESSION_KEY] = user.user_data
+    request.session[HASH_SESSION_KEY] = session_auth_hash
+
+    update_token_in_session(request, user.token)
+
+    if hasattr(request, 'user'):
+        request.user = user
+    rotate_token(request)
+    user_logged_in.send(sender=user.__class__, request=request, user=user)
+
+
+def logout(request):
+    """
+    Removes the authenticated user's ID from the request and flushes their
+    session data.
+    """
+    # Dispatch the signal before the user is logged out so the receivers have a
+    # chance to find out *who* logged out.
+    user = getattr(request, 'user', None)
+    if hasattr(user, 'is_authenticated') and not user.is_authenticated():
+        user = None
+    user_logged_out.send(sender=user.__class__, request=request, user=user)
+
+    request.session.flush()
+
+    if hasattr(request, 'user'):
+        request.user = VerbaAnonymousUser()
+
+
+def get_user(request):
+    """
+    Returns the user model instance associated with the given request session.
+    If no user is retrieved an instance of `VerbaAnonymousUser` is returned.
+    """
+    user = None
+    try:
+        user_id = request.session[SESSION_KEY]
+        token = request.session[AUTH_TOKEN_SESSION_KEY]
+        user_data = request.session[USER_DATA_SESSION_KEY]
+        backend_path = request.session[BACKEND_SESSION_KEY]
+    except KeyError:
+        pass
+    else:
+        if backend_path in settings.AUTHENTICATION_BACKENDS:
+            backend = load_backend(backend_path)
+            user = backend.get_user(user_id, token, user_data)
+            # Verify the session
+            if hasattr(user, 'get_session_auth_hash'):
+                session_hash = request.session.get(HASH_SESSION_KEY)
+                session_hash_verified = session_hash and constant_time_compare(
+                    session_hash,
+                    user.get_session_auth_hash()
+                )
+                if not session_hash_verified:
+                    request.session.flush()
+                    user = None
+
+    return user or VerbaAnonymousUser()

--- a/verba/apps/auth/apps.py
+++ b/verba/apps/auth/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class AuthConfig(AppConfig):
+    name = 'auth'

--- a/verba/apps/auth/backends.py
+++ b/verba/apps/auth/backends.py
@@ -1,0 +1,27 @@
+from . import get_user_model
+from .github import get_token, get_user_data
+from .exceptions import AuthException
+
+
+class VerbaBackend(object):
+    """
+    Django authentication backend which authenticates against the GitHub API.
+    """
+
+    def authenticate(self, code=None):
+        """
+        Returns a valid `VerbaUser` if the authentication is successful
+        or None if the token is invalid.
+        """
+        try:
+            token = get_token(code)
+        except AuthException:
+            return
+        user_data = get_user_data(token)
+
+        UserModel = get_user_model()
+        return UserModel(user_data['id'], token, user_data=user_data)
+
+    def get_user(self, pk, token, user_data={}):
+        UserModel = get_user_model()
+        return UserModel(pk, token, user_data=user_data)

--- a/verba/apps/auth/decorators.py
+++ b/verba/apps/auth/decorators.py
@@ -1,0 +1,50 @@
+from functools import wraps
+
+from django.conf import settings
+from django.contrib.auth import REDIRECT_FIELD_NAME
+from django.shortcuts import resolve_url
+from django.utils.decorators import available_attrs
+from django.utils.six.moves.urllib.parse import urlparse
+
+
+def user_passes_test(test_func, login_url=None, redirect_field_name=REDIRECT_FIELD_NAME):
+    """
+    Decorator for views that checks that the user passes the given test,
+    redirecting to the log-in page if necessary. The test should be a callable
+    that takes the user object and returns True if the user passes.
+    """
+
+    def decorator(view_func):
+        @wraps(view_func, assigned=available_attrs(view_func))
+        def _wrapped_view(request, *args, **kwargs):
+            if test_func(request.user):
+                return view_func(request, *args, **kwargs)
+            path = request.build_absolute_uri()
+            resolved_login_url = resolve_url(login_url or settings.LOGIN_URL)
+            # If the login url is the same scheme and net location then just
+            # use the path as the "next" url.
+            login_scheme, login_netloc = urlparse(resolved_login_url)[:2]
+            current_scheme, current_netloc = urlparse(path)[:2]
+            if ((not login_scheme or login_scheme == current_scheme) and
+                    (not login_netloc or login_netloc == current_netloc)):
+                path = request.get_full_path()
+            from auth.views import redirect_to_login
+            return redirect_to_login(
+                path, resolved_login_url, redirect_field_name)
+        return _wrapped_view
+    return decorator
+
+
+def login_required(function=None, redirect_field_name=REDIRECT_FIELD_NAME, login_url=None):
+    """
+    Decorator for views that checks that the user is logged in, redirecting
+    to the log-in page if necessary.
+    """
+    actual_decorator = user_passes_test(
+        lambda u: u.is_authenticated(),
+        login_url=login_url,
+        redirect_field_name=redirect_field_name
+    )
+    if function:
+        return actual_decorator(function)
+    return actual_decorator

--- a/verba/apps/auth/exceptions.py
+++ b/verba/apps/auth/exceptions.py
@@ -1,0 +1,10 @@
+class AuthException(Exception):
+    pass
+
+
+class Unauthorized(AuthException):
+    pass
+
+
+class AuthValidationError(AuthException):
+    pass

--- a/verba/apps/auth/forms.py
+++ b/verba/apps/auth/forms.py
@@ -1,0 +1,29 @@
+from django import forms
+from django.contrib.auth import authenticate
+
+
+class AuthenticationForm(forms.Form):
+    code = forms.CharField(max_length=254)
+
+    error_messages = {
+        'invalid_login': "An error occurred when trying to log in"
+    }
+
+    def __init__(self, request=None, *args, **kwargs):
+        self.request = request
+        self.user_cache = None
+        super(AuthenticationForm, self).__init__(*args, **kwargs)
+
+    def clean(self):
+        code = self.cleaned_data.get('code')
+
+        self.user_cache = authenticate(code=code)
+        if self.user_cache is None:
+            raise forms.ValidationError(
+                self.error_messages['invalid_login'],
+                code='invalid_login',
+            )
+        return self.cleaned_data
+
+    def get_user(self):
+        return self.user_cache

--- a/verba/apps/auth/github.py
+++ b/verba/apps/auth/github.py
@@ -1,0 +1,64 @@
+import requests
+from urllib.parse import urlencode
+
+from revision.settings import config
+
+from .exceptions import AuthValidationError
+
+
+def get_login_url(callback_url=None):
+    """
+    Returns the GitHub OAuth authorize URL.
+    """
+    params = {
+        'scope': 'public_repo',
+        'client_id': config.GITHUB_AUTH.CLIENT_ID,
+        'allow_signup': 'false'
+    }
+    if callback_url:
+        params['redirect_uri'] = callback_url
+
+    return 'https://github.com/login/oauth/authorize?{}'.format(urlencode(params))
+
+
+def get_token(code):
+    """
+    Returns the GitHub token from the code GH provides or AuthException in case of errors.
+    """
+    params = {
+        'client_id': config.GITHUB_AUTH.CLIENT_ID,
+        'client_secret': config.GITHUB_AUTH.CLIENT_SECRET,
+        'code': code
+    }
+
+    response = requests.post(
+        'https://github.com/login/oauth/access_token',
+        data=params,
+        headers={'Accept': 'application/json'}
+    )
+
+    if not response.ok:
+        raise AuthValidationError('Github response was {}'.format(response.status_code))
+
+    json_response = response.json()
+    if 'error_description' in json_response:
+        raise AuthValidationError(json_response['error_description'])
+
+    return json_response['access_token']
+
+
+def get_user_data(token):
+    """
+    Returns the data of the logged in user associated with the token or AuthException in case of errors.
+    """
+    response = requests.get(
+        'https://api.github.com/user',
+        headers={
+            'Authorization': 'token {}'.format(token)
+        }
+    )
+
+    if not response.ok:
+        raise AuthValidationError('Github response was {}'.format(response.status_code))
+
+    return response.json()

--- a/verba/apps/auth/middleware.py
+++ b/verba/apps/auth/middleware.py
@@ -1,0 +1,33 @@
+from django.utils.functional import SimpleLazyObject
+from django.http import HttpResponseRedirect
+from django.conf import settings
+from django.core.urlresolvers import reverse
+
+from . import logout
+from . import get_user as auth_get_user
+from .exceptions import Unauthorized
+
+
+def get_user(request):
+    """
+    Returns a cached copy of the user if it exists or calls `auth_get_user`
+    otherwise.
+    """
+    if not hasattr(request, '_cached_user'):
+        request._cached_user = auth_get_user(request)
+    return request._cached_user
+
+
+class AuthenticationMiddleware(object):
+    """
+    It simply sets `request.user` so that it can be used in our views.
+
+    The build-in Django one sadly tries to get the user from the database.
+    """
+    def process_request(self, request):
+        request.user = SimpleLazyObject(lambda: get_user(request))
+
+    def process_exception(self, request, exception):
+        if isinstance(exception, Unauthorized):
+            logout(request)
+            return HttpResponseRedirect(reverse(settings.LOGIN_URL))

--- a/verba/apps/auth/models.py
+++ b/verba/apps/auth/models.py
@@ -1,0 +1,47 @@
+from django.utils.crypto import salted_hmac
+
+
+class VerbaUser(object):
+    """
+    Authenticated user, similar to the Django one.
+
+    The built-in Django `AbstractBaseUser` sadly depends on a few tables and
+    cannot be used without a datbase so we had to create a custom one.
+    """
+
+    def __init__(self, pk, token, user_data={}):
+        self.pk = pk
+        self.is_active = True
+
+        self.token = token
+        self.user_data = user_data
+
+    @property
+    def name(self):
+        return self.user_data.get('name')
+
+    def save(self, *args, **kwargs):
+        pass
+
+    def is_authenticated(self, *args, **kwargs):
+        return True
+
+    def get_session_auth_hash(self):
+        """
+        Return an HMAC of the token field.
+        """
+        key_salt = "auth.models.VerbaUser.get_session_auth_hash"
+        return salted_hmac(key_salt, self.token).hexdigest()
+
+
+class VerbaAnonymousUser(object):
+    """
+    Anonymous non-authenticated user, similar to the Django one.
+
+    The built-in Django `AnonymousUser` sadly depends on a few tables and
+    gives several warnings when used without a database so we had to create a
+    custom one.
+    """
+
+    def is_authenticated(self, *args, **kwargs):
+        return False

--- a/verba/apps/auth/tests/test_auth.py
+++ b/verba/apps/auth/tests/test_auth.py
@@ -1,0 +1,125 @@
+from unittest import mock
+
+from django.test import SimpleTestCase
+
+from auth import login, logout, get_user, \
+    SESSION_KEY, BACKEND_SESSION_KEY, USER_DATA_SESSION_KEY, HASH_SESSION_KEY, AUTH_TOKEN_SESSION_KEY
+from auth.models import VerbaUser, VerbaAnonymousUser
+
+
+class LoginTestCase(SimpleTestCase):
+    def test_set_user_into_session(self):
+        """
+        If the session is empty, after calling login, it should get populated with user data.
+        """
+        session = self.client.session
+
+        request = mock.MagicMock(session=session)
+        user = VerbaUser(pk=1, token='user token', user_data={'username': 'verbauser'})
+        user.backend = 'backend'
+
+        login(request, user)
+        self.assertEqual(request.session[SESSION_KEY], user.pk)
+        self.assertEqual(request.session[BACKEND_SESSION_KEY], 'backend')
+        self.assertDictEqual(request.session[USER_DATA_SESSION_KEY], user.user_data)
+        self.assertNotEqual(request.session[HASH_SESSION_KEY], '')
+        self.assertEqual(request.session[AUTH_TOKEN_SESSION_KEY], user.token)
+        self.assertEqual(request.user, user)
+
+    def test_flush_old_session_if_different(self):
+        """
+        If there's another user pk in the session, that value should get reset and overrides by the new one.
+        """
+        old_pk = 'old session'
+
+        session = self.client.session
+        session[SESSION_KEY] = old_pk
+
+        request = mock.MagicMock(session=session)
+        user = VerbaUser(pk=1, token='user token', user_data={'username': 'verbauser'})
+        user.backend = 'backend'
+
+        self.assertEqual(request.session[SESSION_KEY], old_pk)
+        login(request, user)
+        self.assertNotEqual(request.session[SESSION_KEY], old_pk)
+        self.assertEqual(request.session[SESSION_KEY], user.pk)
+
+
+class LogoutTestCase(SimpleTestCase):
+    def test_logged_in(self):
+        """
+        If the user is logged in, after calling logout, the session should get flushed.
+        """
+        session = self.client.session
+        session[SESSION_KEY] = 'some id'
+
+        user = VerbaUser(pk=1, token='user token', user_data={'username': 'verbauser'})
+        request = mock.MagicMock(session=session, user=user)
+        logout(request)
+        self.assertTrue(isinstance(request.user, VerbaAnonymousUser))
+        self.assertFalse(SESSION_KEY in request.session)
+
+    def test_already_logged_out(self):
+        """
+        If the user is already logged out, after calling logout the session should still get flushed.
+        """
+        session = self.client.session
+        session[SESSION_KEY] = 'some id'
+
+        user = VerbaAnonymousUser()
+        request = mock.MagicMock(session=session, user=user)
+        logout(request)
+        self.assertTrue(isinstance(request.user, VerbaAnonymousUser))
+        self.assertFalse(SESSION_KEY in request.session)
+
+
+class GetUserTestCase(SimpleTestCase):
+    def test_when_logged_in(self):
+        """
+        When the values in the session are set up properly, get_user should return the expected VerbaUser.
+        """
+        session = self.client.session
+
+        expected_user = VerbaUser(pk=1, token='user token', user_data={'username': 'verbauser'})
+        session[SESSION_KEY] = expected_user.pk
+        session[AUTH_TOKEN_SESSION_KEY] = expected_user.token
+        session[USER_DATA_SESSION_KEY] = expected_user.user_data
+        session[BACKEND_SESSION_KEY] = 'auth.backends.VerbaBackend'
+        session[HASH_SESSION_KEY] = expected_user.get_session_auth_hash()
+
+        request = mock.MagicMock(session=session)
+
+        user = get_user(request)
+
+        self.assertEqual(user.pk, expected_user.pk)
+        self.assertEqual(user.token, expected_user.token)
+        self.assertDictEqual(user.user_data, expected_user.user_data)
+
+    def test_with_invalid_hash_returns_anonymous(self):
+        """
+        When the values in the session are set up properly APART FROM the HASH SESSION KEY,
+        get_user should return VerbaAnonymousUser
+        """
+        session = self.client.session
+
+        expected_user = VerbaUser(pk=1, token='user token', user_data={'username': 'verbauser'})
+        session[SESSION_KEY] = expected_user.pk
+        session[AUTH_TOKEN_SESSION_KEY] = expected_user.token
+        session[USER_DATA_SESSION_KEY] = expected_user.user_data
+        session[BACKEND_SESSION_KEY] = 'auth.backends.VerbaBackend'
+        session[HASH_SESSION_KEY] = 'some other hash'
+
+        request = mock.MagicMock(session=session)
+
+        user = get_user(request)
+        self.assertTrue(isinstance(user, VerbaAnonymousUser))
+
+    def test_not_logged_in_returns_anonymous(self):
+        """
+        When the session is empty, get_user should return VerbaAnonymousUser.
+        """
+        session = self.client.session
+        request = mock.MagicMock(session=session)
+
+        user = get_user(request)
+        self.assertTrue(isinstance(user, VerbaAnonymousUser))

--- a/verba/apps/auth/tests/test_backends.py
+++ b/verba/apps/auth/tests/test_backends.py
@@ -1,0 +1,31 @@
+from unittest import mock
+
+from django.test import SimpleTestCase
+
+from auth.backends import VerbaBackend
+from auth.exceptions import AuthException
+
+
+@mock.patch('auth.backends.get_token')
+class VerbaBackendTestCase(SimpleTestCase):
+    def test_authenticate_fails(self, mocked_get_token):
+        mocked_get_token.side_effect = AuthException()
+
+        backend = VerbaBackend()
+        self.assertEqual(backend.authenticate(code='code'), None)
+
+    @mock.patch('auth.backends.get_user_data')
+    def test_success(self, mocked_get_user_data, mocked_get_token):
+        token = 'token'
+        user_data = {
+            'id': 1
+        }
+
+        mocked_get_token.return_value = token
+        mocked_get_user_data.return_value = user_data
+
+        backend = VerbaBackend()
+        user = backend.authenticate(code='code')
+        self.assertEqual(user.pk, user_data['id'])
+        self.assertEqual(user.token, token)
+        self.assertDictEqual(user.user_data, user_data)

--- a/verba/apps/auth/tests/test_forms.py
+++ b/verba/apps/auth/tests/test_forms.py
@@ -1,0 +1,41 @@
+from unittest import mock
+
+from django.test.testcases import SimpleTestCase
+from django.utils.encoding import force_text
+
+from auth.forms import AuthenticationForm
+
+
+@mock.patch('auth.forms.authenticate')
+class AuthenticationFormTestCase(SimpleTestCase):
+    def setUp(self):
+        super(AuthenticationFormTestCase, self).setUp()
+        self.data = {
+            'code': '123456789'
+        }
+
+    def test_invalid_code(self, mocked_authenticate):
+        """
+        Invalid code supplied.
+        """
+        mocked_authenticate.return_value = None
+
+        form = AuthenticationForm(data=self.data)
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            form.non_field_errors(),
+            [force_text(form.error_messages['invalid_login'])]
+        )
+
+        mocked_authenticate.assert_called_with(**self.data)
+
+    def test_success(self, mocked_authenticate):
+        user = mock.MagicMock()
+        mocked_authenticate.return_value = user
+
+        form = AuthenticationForm(data=self.data)
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.non_field_errors(), [])
+        self.assertTrue(form.get_user(), user)
+
+        mocked_authenticate.assert_called_with(**self.data)

--- a/verba/apps/auth/tests/test_github.py
+++ b/verba/apps/auth/tests/test_github.py
@@ -1,0 +1,75 @@
+import json
+import responses
+
+from django.test import SimpleTestCase
+
+from auth.github import get_token, get_user_data
+from auth.exceptions import AuthValidationError
+
+
+class GetTokenTestCase(SimpleTestCase):
+    @responses.activate
+    def test_success(self):
+        expected_token = 'token'
+        responses.add(
+            responses.POST, 'https://github.com/login/oauth/access_token',
+            body=json.dumps({"access_token": expected_token}), status=200,
+            content_type='application/json'
+        )
+
+        token = get_token(code='code')
+        self.assertEqual(token, expected_token)
+
+    @responses.activate
+    def test_invalid_code(self):
+        response_body = {
+            'error': 'bad_verification_code',
+            'error_uri': 'https://developer.github.com/v3/oauth/#bad-verification-code',
+            'error_description': 'The code passed is incorrect or expired.'
+        }
+        responses.add(
+            responses.POST, 'https://github.com/login/oauth/access_token',
+            body=json.dumps(response_body), status=200,
+            content_type='application/json'
+        )
+
+        self.assertRaises(AuthValidationError, get_token, code='code')
+
+    @responses.activate
+    def test_github_returns_404(self):
+        responses.add(
+            responses.POST, 'https://github.com/login/oauth/access_token',
+            status=404,
+            content_type='application/json'
+        )
+
+        self.assertRaises(AuthValidationError, get_token, code='code')
+
+
+class GetUserDataTestCase(SimpleTestCase):
+    @responses.activate
+    def test_success(self):
+        expected_user_data = {'id': 1}
+        responses.add(
+            responses.GET, 'https://api.github.com/user',
+            body=json.dumps(expected_user_data), status=200,
+            content_type='application/json'
+        )
+
+        user_data = get_user_data(token='token')
+        self.assertDictEqual(user_data, expected_user_data)
+
+    @responses.activate
+    def test_invalid_token(self):
+        response_body = {
+            'message': 'Bad credentials',
+            'documentation_url': 'https://developer.github.com/v3'
+        }
+
+        responses.add(
+            responses.GET, 'https://api.github.com/user',
+            body=json.dumps(response_body), status=401,
+            content_type='application/json'
+        )
+
+        self.assertRaises(AuthValidationError, get_user_data, token='invalid token')

--- a/verba/apps/auth/tests/test_views.py
+++ b/verba/apps/auth/tests/test_views.py
@@ -1,0 +1,96 @@
+import json
+import responses
+
+from django.conf import settings
+from django.test import SimpleTestCase
+from django.contrib.auth import REDIRECT_FIELD_NAME
+from django.core.urlresolvers import reverse
+
+from auth import SESSION_KEY, BACKEND_SESSION_KEY, \
+    AUTH_TOKEN_SESSION_KEY, USER_DATA_SESSION_KEY
+
+
+class AuthenticatedTestCase(SimpleTestCase):
+    def setUp(self):
+        super(AuthenticatedTestCase, self).setUp()
+
+        # next is a 404 so that it doesn't trigger any other external call
+        self.callback_url = '{}?code={}&redirect_url={}'.format(
+            reverse('auth:callback'),
+            'code',
+            '/test-login-success/'
+        )
+
+    @responses.activate
+    def login(self, token="123456789", user_data={'id': 1}):
+        responses.add(
+            responses.POST, 'https://github.com/login/oauth/access_token',
+            body=json.dumps({"access_token": token}), status=200,
+            content_type='application/json'
+        )
+        responses.add(
+            responses.GET, 'https://api.github.com/user',
+            body=json.dumps(user_data), status=200,
+            content_type='application/json'
+        )
+
+        response = self.client.get(self.callback_url)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            self.client.session[SESSION_KEY], user_data['id']
+        )
+
+
+class LoginViewTestCase(AuthenticatedTestCase):
+    def test_success(self):
+        token = "123456789"
+        user_data = {'id': 1}
+        self.login(token, user_data=user_data)
+
+        self.assertEqual(
+            self.client.session[SESSION_KEY], user_data['id']
+        )
+        self.assertEqual(
+            self.client.session[BACKEND_SESSION_KEY],
+            settings.AUTHENTICATION_BACKENDS[0]
+        )
+        self.assertEqual(
+            self.client.session[AUTH_TOKEN_SESSION_KEY], token
+        )
+        self.assertDictEqual(
+            self.client.session[USER_DATA_SESSION_KEY], user_data
+        )
+
+    @responses.activate
+    def test_invalid_auth_code(self):
+        response_body = {
+            'error': 'bad_verification_code',
+            'error_uri': 'https://developer.github.com/v3/oauth/#bad-verification-code',
+            'error_description': 'The code passed is incorrect or expired.'
+        }
+        responses.add(
+            responses.POST, 'https://github.com/login/oauth/access_token',
+            body=json.dumps(response_body), status=200,
+            content_type='application/json'
+        )
+        response = self.client.get(self.callback_url)
+        self.assertEqual(response.status_code, 401)
+
+
+class LogoutViewTestCase(AuthenticatedTestCase):
+    def setUp(self):
+        super(LogoutViewTestCase, self).setUp()
+
+        # next is a 404 so that it doesn't trigger any other external call
+        self.logout_url = '{}?{}={}'.format(
+            reverse('auth:logout'),
+            REDIRECT_FIELD_NAME, '/test-logout-success/'
+        )
+
+    def test_logout_clears_session(self):
+        self.login()
+
+        self.client.get(self.logout_url, follow=True)
+
+        # nothing in the session
+        self.assertEqual(len(self.client.session.items()), 0)

--- a/verba/apps/auth/urls.py
+++ b/verba/apps/auth/urls.py
@@ -1,0 +1,10 @@
+from django.conf.urls import url
+
+from . import views
+
+
+urlpatterns = [
+    url(r'^login/$', views.LoginView.as_view(), name='login'),
+    url(r'^callback/$', views.CallbackView.as_view(), name='callback'),
+    url(r'^logout/$', views.LogoutView.as_view(), name='logout'),
+]

--- a/verba/apps/auth/views.py
+++ b/verba/apps/auth/views.py
@@ -1,0 +1,93 @@
+from django.conf import settings
+from django.views.generic.base import View
+from django.contrib.auth import REDIRECT_FIELD_NAME
+from django.http import HttpResponse, HttpResponseRedirect
+from django.utils.http import is_safe_url
+from django.core.urlresolvers import reverse
+from django.shortcuts import resolve_url
+from django.utils.six.moves.urllib.parse import urlparse, urlunparse
+from django.http import QueryDict
+
+from . import login as auth_login, logout as auth_logout
+from .forms import AuthenticationForm
+from .github import get_login_url
+
+
+class LoginView(View):
+    """
+    Redirects to the GitHub authenticate URL.
+    """
+    def get(self, request, *args, **kwargs):
+        # check if next page is in URL
+        redirect_to = request.POST.get(
+            REDIRECT_FIELD_NAME,
+            request.GET.get(REDIRECT_FIELD_NAME, '')
+        )
+
+        # Security check -- don't allow redirection to a different host.
+        if redirect_to and not is_safe_url(url=redirect_to, host=request.get_host()):
+            redirect_to = None
+
+        # if next, construct callback_url else leave it None and the default one will be used
+        callback_url = None
+        if redirect_to:
+            callback_url = '{}?redirect_url={}'.format(
+                request.build_absolute_uri(reverse('auth:callback')),
+                redirect_to
+            )
+
+        url = get_login_url(callback_url=callback_url)
+        return HttpResponseRedirect(url)
+
+
+class CallbackView(View):
+    """
+    Called by GitHub when authenticating.
+    """
+    def get(self, request, *args, **kwargs):
+        redirect_url = request.GET.get('redirect_url', '/')
+
+        form = AuthenticationForm(request, request.GET)
+
+        if form.is_valid():
+            auth_login(request, form.get_user())
+            return HttpResponseRedirect(redirect_url)
+
+        return HttpResponse('Unauthorized', status=401)
+
+
+class LogoutView(View):
+    def get(self, request, *args, **kwargs):
+        auth_logout(request)
+
+        next_page = None
+        if (REDIRECT_FIELD_NAME in request.POST or
+                REDIRECT_FIELD_NAME in request.GET):
+            next_page = request.POST.get(
+                REDIRECT_FIELD_NAME, request.GET.get(REDIRECT_FIELD_NAME)
+            )
+            # Security check -- don't allow redirection to a different host.
+            if not is_safe_url(url=next_page, host=request.get_host()):
+                next_page = request.path
+
+        if next_page:
+            # Redirect to this page until the session has been cleared.
+            return HttpResponseRedirect(next_page)
+
+        return HttpResponseRedirect('/')
+
+
+def redirect_to_login(next, login_url=None,
+                      redirect_field_name=REDIRECT_FIELD_NAME):
+    """
+    Redirects the user to the login page, passing the given 'next' page
+    """
+    resolved_url = resolve_url(login_url or settings.LOGIN_URL)
+
+    login_url_parts = list(urlparse(resolved_url))
+    if redirect_field_name:
+        querystring = QueryDict(login_url_parts[4], mutable=True)
+        querystring[redirect_field_name] = next
+        login_url_parts[4] = querystring.urlencode(safe='/')
+
+    return HttpResponseRedirect(urlunparse(login_url_parts))

--- a/verba/apps/revision/urls.py
+++ b/verba/apps/revision/urls.py
@@ -1,4 +1,5 @@
 from django.conf.urls import url
+from auth.decorators import login_required
 
 from . import views
 
@@ -6,37 +7,37 @@ from . import views
 urlpatterns = [
     url(
         r'^$',
-        views.RevisionList.as_view(),
+        login_required(views.RevisionList.as_view()),
         name='list'
     ),
     url(
         r'^new/$',
-        views.NewRevision.as_view(),
+        login_required(views.NewRevision.as_view()),
         name='new'
     ),
     url(
         r'^detail/(?P<revision_id>[\w-]+)/$',
-        views.RevisionDetail.as_view(),
+        login_required(views.RevisionDetail.as_view()),
         name='detail'
     ),
     url(
         r'^detail/(?P<revision_id>[\w-]+)/(?P<file_path>.+)$',
-        views.RevisionFileDetail.as_view(),
+        login_required(views.RevisionFileDetail.as_view()),
         name='file-detail'
     ),
     url(
         r'^send-for-approval/(?P<revision_id>[\w-]+)/$',
-        views.SendForApproval.as_view(),
+        login_required(views.SendForApproval.as_view()),
         name='send-for-approval'
     ),
     url(
         r'^preview/(?P<revision_id>[\w-]+)/$',
-        views.Preview.as_view(),
+        login_required(views.Preview.as_view()),
         name='preview'
     ),
     url(
         r'^delete/(?P<revision_id>[\w-]+)/$',
-        views.DeleteRevision.as_view(),
+        login_required(views.DeleteRevision.as_view()),
         name='delete'
     ),
 ]

--- a/verba/assets/css/styles.css
+++ b/verba/assets/css/styles.css
@@ -28,3 +28,6 @@
 .actions {
   float: right;
 }
+.fl {
+  float: right;
+}

--- a/verba/settings/base.py
+++ b/verba/settings/base.py
@@ -21,12 +21,13 @@ ALLOWED_HOSTS = []
 # Application definition
 
 INSTALLED_APPS = [
-    # 'django.contrib.sessions',
+    'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles'
 ]
 
 PROJECT_APPS = [
+    'auth',
     'revision',
 ]
 
@@ -35,9 +36,11 @@ INSTALLED_APPS += PROJECT_APPS
 MESSAGE_STORAGE = 'django.contrib.messages.storage.cookie.CookieStorage'
 
 MIDDLEWARE_CLASSES = [
+    'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
+    'auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
@@ -87,6 +90,7 @@ TEMPLATES = [
             'debug': DEBUG,
             'context_processors': [
                 'django.template.context_processors.static',
+                'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
             ],
         },
@@ -114,6 +118,10 @@ AUTH_PASSWORD_VALIDATORS = [
 VERBA_GITHUB_TOKEN = None  # GitHub token for access to API
 VERBA_CONFIG = {
     'REPO': None,  # GitHub repo with content files to edit in format '<org>/<repo>'
+    'GITHUB_AUTH': {
+        'CLIENT_ID': None,
+        'CLIENT_SECRET': None,
+    },
     'PATHS': {
         'CONTENT_FOLDER': 'pages/',  # path to folder containing the content files
         'REVISIONS_LOG_FOLDER': 'content-revision-logs/',  # path to folder that will include revision files
@@ -133,6 +141,20 @@ VERBA_CONFIG = {
         'URL_GENERATOR': lambda rev: None  # lambda generator or the preview url
     }
 }
+
+AUTH_USER_MODEL = 'auth.models.VerbaUser'
+LOGIN_URL = 'auth:login'
+SESSION_ENGINE = 'django.contrib.sessions.backends.signed_cookies'
+AUTHENTICATION_BACKENDS = (
+    'auth.backends.VerbaBackend',
+)
+SECURE_CONTENT_TYPE_NOSNIFF = True
+SESSION_COOKIE_HTTPONLY = True
+SESSION_COOKIE_SECURE = False
+SESSION_EXPIRE_AT_BROWSER_CLOSE = True
+CSRF_COOKIE_HTTPONLY = True
+CSRF_COOKIE_SECURE = False
+
 
 from django.contrib.messages import constants as message_constants
 MESSAGE_TAGS = {

--- a/verba/settings/production.py
+++ b/verba/settings/production.py
@@ -16,10 +16,12 @@ ADMINS = (
 MANAGERS = ADMINS
 
 MIDDLEWARE_CLASSES = [
+    'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
+    'auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
@@ -29,3 +31,9 @@ VERBA_CONFIG['REPO'] = os.environ["VERBA_REPO"]
 VERBA_CONFIG['REVIEW_GITHUB_USERS'] = os.environ["VERBA_REVIEW_GITHUB_USERS"]
 VERBA_CONFIG['PREVIEW']['URL_GENERATOR'] = \
     lambda rev: os.environ["VERBA_REVIEW_URL_GENERATOR"].format(rev._pull.issue_nr)
+
+
+SECURE_SSL_REDIRECT = True
+SECURE_HSTS_SECONDS = 300
+SESSION_COOKIE_SECURE = True
+CSRF_COOKIE_SECURE = True

--- a/verba/templates/base.html
+++ b/verba/templates/base.html
@@ -31,6 +31,13 @@
 
     <nav id="top-header" class="navbar navbar-light bg-faded">
       <a class="navbar-brand" href="{% url 'revision:list' %}">Verba - Content Editor for Content Designers</a>
+      <span class="navbar-brand fl">
+        {% if user.is_authenticated %}
+        Hi, {{ user.name }}! <a href="{% url 'auth:logout' %}">Logout</a>
+        {% else %}
+        <a href="{% url 'auth:login' %}">Login</a>
+        {% endif %}
+      </span>
     </nav>
 
     <div class="container">

--- a/verba/urls.py
+++ b/verba/urls.py
@@ -5,4 +5,5 @@ from django.conf.urls import url, include
 urlpatterns = [
     url(r'^$', RedirectView.as_view(url='/revision/', permanent=False), name='index'),
     url(r'^revision/', include('revision.urls', namespace='revision')),
+    url(r'^auth/', include('auth.urls', namespace='auth')),
 ]


### PR DESCRIPTION
This adds GitHub login/logout logic.
As Django depends strongly on a db, this replicates the django logic but using a more simple storage which consists of signed cookies.

In this way, we don't need to depend on an external database and we don't need to keep secrets in a centralised system.

Replicating the django logic, allows us to use the standard and well known way of accessing the logged-in user using request.user and protecting views with the login_required decorator.