### PR TITLE
Add logic for creating a new revision

### DIFF
--- a/verba/apps/revision/constants.py
+++ b/verba/apps/revision/constants.py
@@ -1,0 +1,4 @@
+BRANCH_PARTS_SEPARATOR = '|'
+
+REVISION_LOG_FILE_COMMIT_MSG = 'Create revision log file'
+REVISION_BODY_MSG = 'Content revision "{title}"'

--- a/verba/apps/revision/forms.py
+++ b/verba/apps/revision/forms.py
@@ -1,0 +1,32 @@
+from django import forms
+
+from .constants import BRANCH_PARTS_SEPARATOR
+
+
+class BaseForm(forms.Form):
+    def __init__(self, *args, **kwargs):
+        super(BaseForm, self).__init__(*args, **kwargs)
+
+        for field_name, field in self.fields.items():
+            field.widget.attrs['class'] = 'form-control'
+
+
+class NewRevisionForm(BaseForm):
+    title = forms.CharField(max_length=30)
+
+    def __init__(self, *args, **kwargs):
+        self.revision_manager = kwargs.pop('revision_manager')
+        super(NewRevisionForm, self).__init__(*args, **kwargs)
+
+    def clean_title(self):
+        """
+        Raises Error if `BRANCH_PARTS_SEPARATOR` in title.
+        """
+        title = self.cleaned_data['title']
+        if BRANCH_PARTS_SEPARATOR in title:
+            raise forms.ValidationError("Char '{}' not allowed".format(BRANCH_PARTS_SEPARATOR))
+        return title
+
+    def save(self, creator):
+        title = self.cleaned_data['title']
+        return self.revision_manager.create(title, creator)

--- a/verba/apps/revision/models.py
+++ b/verba/apps/revision/models.py
@@ -1,14 +1,11 @@
+from django.utils import timezone
+
 from github import Repo
 
 from verba_settings import config
 
-
-def is_verba_branch(name):
-    """
-    Returns True if the branch `name` is a Verba branch, that is,
-    created by Verba.
-    """
-    return name.startswith(config.BRANCHES.NAMESPACE)
+from .utils import is_verba_branch, generate_verba_branch_name, get_verba_branch_name_info
+from .constants import REVISION_LOG_FILE_COMMIT_MSG, REVISION_BODY_MSG
 
 
 class Revision(object):
@@ -22,17 +19,50 @@ class Revision(object):
 
     @property
     def statuses(self):
-        return filter(
-            lambda label: label in config.LABELS.ALLOWED,
-            self._pull.labels
+        return list(
+            filter(
+                lambda label: label in config.LABELS.ALLOWED,
+                self._pull.labels
+            )
         )
 
     @property
     def assignees(self):
-        return filter(
-            lambda assignee: assignee in config.ASSIGNEES.ALLOWED,
-            self._pull.assignees
+        return list(
+            filter(
+                lambda assignee: assignee in config.ASSIGNEES.ALLOWED,
+                self._pull.assignees
+            )
         )
+
+    @property
+    def creator(self):
+        _, _, creator, _ = get_verba_branch_name_info(self.id)
+        return creator
+
+    def move_to_draft(self):
+        """
+        Moves the revision to the draft state, meaning:
+        - sets the status to draft
+        - sets the assignee to the creator
+
+        This without losing any of the settings that verba does not understand.
+        """
+        # labels
+        # 1. don't lose any unknown labels
+        labels = [label for label in self._pull.labels if label not in config.LABELS.ALLOWED]
+        # 2. add only the draft one
+        labels.append(config.LABELS.DRAFT)
+        # 3. set labels
+        self._pull.labels = labels
+
+        # assignees
+        # 1. don't lose any unknown assignees
+        assignees = [assignee for assignee in self._pull.assignees if assignee not in config.ASSIGNEES.ALLOWED]
+        # 2. add only the creator
+        assignees.append(self.creator)
+        # 3. set assignees
+        self._pull.assignees = assignees
 
 
 class RevisionManager(object):
@@ -52,3 +82,49 @@ class RevisionManager(object):
                 Revision(pull=pull, revision_id=pull.head_ref)
             )
         return revisions
+
+    def create(self, title, creator):
+        """
+        Creates a new revisions meaning:
+        - creates a new branch
+        - creates an empty file and adds it to the REVISIONS_LOG_FOLDER
+        - creates a new PR
+        - marks the PR as in draft
+        - assigns the PR to the creator
+        """
+        assert(title and creator)
+
+        # generating branch name
+        branch_name = generate_verba_branch_name(title, creator)
+
+        # create branch
+        branch = self._repo.create_branch(
+            new_branch=branch_name,
+            from_branch=config.BRANCHES.BASE
+        )
+
+        # create revision log file in log folder
+        revision_log_file_path = '{}{}_{}'.format(
+            config.PATHS.REVISIONS_LOG_FOLDER,
+            timezone.now().strftime('%Y.%m.%d_%H.%M'),
+            branch_name
+        )
+
+        branch.create_new_file(
+            path=revision_log_file_path,
+            message=REVISION_LOG_FILE_COMMIT_MSG,
+            content=''
+        )
+
+        # create PR
+        pull = self._repo.create_pull(
+            title=title,
+            body=REVISION_BODY_MSG.format(title=title),
+            base=config.BRANCHES.BASE,
+            head=branch_name
+        )
+
+        revision = Revision(pull, branch_name)
+        revision.move_to_draft()
+
+        return revision

--- a/verba/apps/revision/tests/test_forms.py
+++ b/verba/apps/revision/tests/test_forms.py
@@ -1,0 +1,49 @@
+from unittest import mock
+
+from django.test.testcases import SimpleTestCase
+
+from revision.forms import NewRevisionForm
+from revision.constants import BRANCH_PARTS_SEPARATOR
+
+
+class NewRevisionFormTestCase(SimpleTestCase):
+    def setUp(self):
+        super(NewRevisionFormTestCase, self).setUp()
+        self.revision_manager = mock.MagicMock()
+
+    def test_valid(self):
+        data = {'title': 'test title'}
+        creator = 'test-owner'
+
+        form = NewRevisionForm(
+            revision_manager=self.revision_manager,
+            data=data
+        )
+
+        self.assertTrue(form.is_valid())
+
+        form.save(creator)
+        self.revision_manager.create.assert_called_with(data['title'], creator)
+
+    def test_empty_title(self):
+        form = NewRevisionForm(
+            revision_manager=self.revision_manager,
+            data={'title': ''}
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertEqual(form.errors['title'], ['This field is required.'])
+
+    def test_invalid_char_in_title(self):
+        form = NewRevisionForm(
+            revision_manager=self.revision_manager,
+            data={
+                'title': 'test {} title'.format(BRANCH_PARTS_SEPARATOR)
+            }
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            form.errors['title'],
+            ["Char '{}' not allowed".format(BRANCH_PARTS_SEPARATOR)]
+        )

--- a/verba/apps/revision/tests/test_models.py
+++ b/verba/apps/revision/tests/test_models.py
@@ -1,37 +1,22 @@
+import datetime
 from unittest import mock
 
 from verba_settings import config
 
 from django.test import SimpleTestCase
 
-from revision.models import is_verba_branch, RevisionManager, Revision
+from revision.models import RevisionManager, Revision
+from revision.utils import generate_verba_branch_name
+from revision.constants import REVISION_LOG_FILE_COMMIT_MSG, REVISION_BODY_MSG
 
 
-class IsVerbaBranchTestCase(SimpleTestCase):
-    def test_true(self):
-        self.assertTrue(
-            is_verba_branch(config.BRANCHES.NAMESPACE)
-        )
-        self.assertTrue(
-            is_verba_branch('{}test'.format(config.BRANCHES.NAMESPACE))
-        )
-
-    def test_false(self):
-        self.assertFalse(
-            is_verba_branch(config.BRANCHES.NAMESPACE.upper())
-        )
-        self.assertFalse(
-            is_verba_branch('some-test')
-        )
-
-
+@mock.patch('revision.models.Repo')
 class RevisionManagerTestCase(SimpleTestCase):
-    @mock.patch('revision.models.Repo')
     def test_get_all(self, MockedRepo):  # noqa
         pulls = [
-            mock.MagicMock(head_ref='{}test1'.format(config.BRANCHES.NAMESPACE)),
+            mock.MagicMock(head_ref=generate_verba_branch_name('test1', 'test-owner')),
             mock.MagicMock(head_ref='another-name'),
-            mock.MagicMock(head_ref='{}test2'.format(config.BRANCHES.NAMESPACE)),
+            mock.MagicMock(head_ref=generate_verba_branch_name('test2', 'test-owner')),
         ]
         MockedRepo().get_pulls.return_value = pulls
 
@@ -41,11 +26,49 @@ class RevisionManagerTestCase(SimpleTestCase):
         self.assertEqual(len(revisions), 2)
         self.assertEqual(
             sorted([rev.id for rev in revisions]),
-            [
-                '{}test1'.format(config.BRANCHES.NAMESPACE),
-                '{}test2'.format(config.BRANCHES.NAMESPACE)
-            ]
+            [pulls[0].head_ref, pulls[2].head_ref]
         )
+
+    @mock.patch('revision.models.timezone')
+    def test_create(self, mocked_timezone, MockedRepo):  # noqa
+        title = 'test-title'
+        creator = 'test-owner'
+        manager = RevisionManager(token='123456')
+        mocked_timezone.now.return_value = datetime.datetime(day=1, month=1, year=2016)
+
+        rev = manager.create(title, creator)
+
+        mocked_repo = MockedRepo()
+
+        # check create_branch called
+        mocked_create_branch = mocked_repo.create_branch
+        mocked_create_branch.assert_called_with(
+            new_branch=rev.id,
+            from_branch=config.BRANCHES.BASE
+        )
+
+        # checked new file revision log created
+        mocked_branch = mocked_create_branch()
+        mocked_branch.create_new_file.assert_called_with(
+            content='',
+            message=REVISION_LOG_FILE_COMMIT_MSG,
+            path='{}2016.01.01_00.00_{}'.format(
+                config.PATHS.REVISIONS_LOG_FOLDER,
+                rev.id
+            )
+        )
+
+        # check PR created
+        mocked_repo.create_pull.assert_called_with(
+            title=title,
+            body=REVISION_BODY_MSG.format(title=title),
+            base=config.BRANCHES.BASE,
+            head=rev.id
+        )
+
+        # check status and assignee
+        self.assertEqual(rev.statuses, [config.LABELS.DRAFT])
+        self.assertEqual(rev.assignees, ['test-owner'])
 
 
 class RevisionTestCase(SimpleTestCase):
@@ -57,7 +80,7 @@ class RevisionTestCase(SimpleTestCase):
                 labels=config.LABELS.ALLOWED + ['another-label'],
                 assignees=config.ASSIGNEES.ALLOWED + ['another-user']
             ),
-            revision_id='some-id'
+            revision_id=generate_verba_branch_name('test title', 'test-owner')
         )
 
     def test_title(self):
@@ -75,4 +98,31 @@ class RevisionTestCase(SimpleTestCase):
         self.assertEqual(
             sorted(self.revision.assignees),
             sorted(config.ASSIGNEES.ALLOWED)
+        )
+
+    def test_creator(self):
+        self.assertEqual(
+            self.revision.creator,
+            'test-owner'
+        )
+
+    def test_move_to_draft(self):
+        self.revision.move_to_draft()
+
+        self.assertEqual(
+            self.revision.statuses,
+            [config.LABELS.DRAFT]
+        )
+        self.assertEqual(
+            sorted(self.revision._pull.labels),
+            sorted(['another-label', config.LABELS.DRAFT])
+        )
+
+        self.assertEqual(
+            self.revision.assignees,
+            ['test-owner']
+        )
+        self.assertEqual(
+            sorted(self.revision._pull.assignees),
+            sorted(['another-user', 'test-owner'])
         )

--- a/verba/apps/revision/tests/test_utils.py
+++ b/verba/apps/revision/tests/test_utils.py
@@ -1,0 +1,96 @@
+from django.test import SimpleTestCase
+
+from verba_settings import config
+
+from revision.utils import is_verba_branch, generate_verba_branch_name, get_verba_branch_name_info
+from revision.constants import BRANCH_PARTS_SEPARATOR
+
+
+class IsVerbaBranchTestCase(SimpleTestCase):
+    def test_true(self):
+        parts = [
+            config.BRANCHES.NAMESPACE,
+            'title',
+            'some-creator',
+            'random-string'
+        ]
+
+        self.assertTrue(
+            is_verba_branch(BRANCH_PARTS_SEPARATOR.join(parts))
+        )
+
+    def test_false(self):
+        parts = [
+            config.BRANCHES.NAMESPACE,
+            'title',
+            'some-creator',
+            'random-string'
+        ]
+
+        self.assertFalse(
+            is_verba_branch(BRANCH_PARTS_SEPARATOR.join(parts[1:]))
+        )
+        self.assertFalse(
+            is_verba_branch(BRANCH_PARTS_SEPARATOR.join(parts[:-1]))
+        )
+        self.assertFalse(
+            is_verba_branch('%'.join(parts))
+        )
+
+
+class GenerateVerbaBranchNameTestCase(SimpleTestCase):
+    def test_generate(self):
+        title = 'test title'
+        creator = 'test-owner'
+
+        branch_name = generate_verba_branch_name(title, creator)
+
+        parts = branch_name.split(BRANCH_PARTS_SEPARATOR)
+        self.assertEqual(len(parts), 4)
+        self.assertEqual(parts[0], config.BRANCHES.NAMESPACE)
+        self.assertEqual(parts[1], 'test-title')
+        self.assertEqual(parts[2], 'test-owner')
+
+
+class GetVerbaBranchNameInfo(SimpleTestCase):
+    def test_valid(self):
+        parts = [
+            config.BRANCHES.NAMESPACE,
+            'test-title',
+            'some-creator',
+            'random-string'
+        ]
+        branch_name = BRANCH_PARTS_SEPARATOR.join(parts)
+
+        namespace, title, creator, random_string = get_verba_branch_name_info(branch_name)
+        self.assertEqual(namespace, parts[0])
+        self.assertEqual(title, parts[1])
+        self.assertEqual(creator, parts[2])
+        self.assertEqual(random_string, parts[3])
+
+    def test_invalid(self):
+        parts = [
+            config.BRANCHES.NAMESPACE,
+            'test-title',
+            'some-creator',
+            'random-string'
+        ]
+
+        self.assertEqual(
+            get_verba_branch_name_info('%'.join(parts)),
+            (None, None, None, None)
+        )
+
+        self.assertEqual(
+            get_verba_branch_name_info(BRANCH_PARTS_SEPARATOR.join(parts[1:])),
+            (None, None, None, None)
+        )
+        self.assertEqual(
+            get_verba_branch_name_info(BRANCH_PARTS_SEPARATOR.join(parts[:-1])),
+            (None, None, None, None)
+        )
+
+        self.assertEqual(
+            get_verba_branch_name_info('random-string'),
+            (None, None, None, None)
+        )

--- a/verba/apps/revision/tests/test_views.py
+++ b/verba/apps/revision/tests/test_views.py
@@ -25,3 +25,34 @@ class RevisionListTestCase(AuthTestCase):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         self.assertListEqual(response.context['revisions'], revisions)
+
+
+class NewRevisionTestCase(AuthTestCase):
+    def setUp(self):
+        super(NewRevisionTestCase, self).setUp()
+        self.url = reverse('revision:new')
+
+    def test_redirects_to_login(self):
+        self._test_redirects_to_login(self.url)
+
+    @mock.patch('revision.views.RevisionManager')
+    def test_invalid_title(self, MockedRevisionManager):  # noqa
+        self.login()
+
+        response = self.client.post(self.url, data={
+            'title': ''
+        })
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.context['form'].errors)
+
+    @mock.patch('revision.views.RevisionManager')
+    def test_success(self, MockedRevisionManager):  # noqa
+        self.login()
+
+        title = 'test title'
+        response = self.client.post(self.url, data={'title': title})
+        self.assertEqual(response.status_code, 302)
+
+        MockedRevisionManager().create_assert_called_with(
+            title, self.get_user_data()['login']
+        )

--- a/verba/apps/revision/urls.py
+++ b/verba/apps/revision/urls.py
@@ -9,4 +9,9 @@ urlpatterns = [
         login_required(views.RevisionList.as_view()),
         name='list'
     ),
+    url(
+        r'^new/$',
+        login_required(views.NewRevision.as_view()),
+        name='new'
+    ),
 ]

--- a/verba/apps/revision/utils.py
+++ b/verba/apps/revision/utils.py
@@ -1,0 +1,42 @@
+from django.utils.text import slugify
+from django.utils.crypto import get_random_string
+
+from verba_settings import config
+
+from .constants import BRANCH_PARTS_SEPARATOR
+
+
+def is_verba_branch(name):
+    """
+    Returns True if the branch `name` is a Verba branch, that is,
+    created by Verba.
+    """
+    namespace, _, _, _ = get_verba_branch_name_info(name)
+    return bool(namespace)
+
+
+def generate_verba_branch_name(title, creator):
+    """
+    Generates a verba branch name from `title` and `creator`.
+    """
+    return BRANCH_PARTS_SEPARATOR.join([
+        config.BRANCHES.NAMESPACE,
+        slugify(title[:10]),
+        creator,
+        get_random_string(length=10)
+    ])
+
+
+def get_verba_branch_name_info(branch_name):
+    """
+    Returns a tuple of:
+        (namespace, slugified title, creator, random string)
+    or
+        (None, None, None, None)
+    if `branch_name` is not a valid Verba branch
+    """
+    parts = branch_name.split(BRANCH_PARTS_SEPARATOR)
+    if len(parts) != 4 or parts[0] != config.BRANCHES.NAMESPACE:
+        return (None, None, None, None)
+
+    return tuple(parts)

--- a/verba/apps/revision/views.py
+++ b/verba/apps/revision/views.py
@@ -1,6 +1,9 @@
-from django.views.generic import TemplateView
+from django.views.generic import TemplateView, FormView
+from django.contrib import messages
+from django.core.urlresolvers import reverse
 
 from .models import RevisionManager
+from .forms import NewRevisionForm
 
 
 class RevisionMixin(object):
@@ -19,3 +22,21 @@ class RevisionList(RevisionMixin, TemplateView):
         context = super(RevisionList, self).get_context_data(**kwargs)
         context['revisions'] = self.revision_manager.get_all()
         return context
+
+
+class NewRevision(RevisionMixin, FormView):
+    form_class = NewRevisionForm
+    template_name = 'revision/new.html'
+
+    def get_form_kwargs(self):
+        kwargs = super(NewRevision, self).get_form_kwargs()
+        kwargs['revision_manager'] = self.revision_manager
+        return kwargs
+
+    def form_valid(self, form):
+        self.revision = form.save(self.request.user.pk)
+        messages.success(self.request, 'Revision created.')
+        return super(NewRevision, self).form_valid(form)
+
+    def get_success_url(self):
+        return reverse('revision:list')

--- a/verba/settings/base.py
+++ b/verba/settings/base.py
@@ -123,15 +123,22 @@ VERBA_CONFIG = {
         'CLIENT_ID': None,
         'CLIENT_SECRET': None,
     },
+    'PATHS': {
+        'REVISIONS_LOG_FOLDER': 'content-revision-logs/',  # path to folder that will contain revision files
+    },
     'BRANCHES': {
-        'NAMESPACE': 'content-'  # prefix of the branches that will be created
+        'NAMESPACE': 'content',  # prefix of the branches that will be created
+        'BASE': 'develop',  # base branch for PRs
     },
     'LABELS': {
-        'ALLOWED': ['draft', '2i', 'queued']  # all labels used by Verba, not the ones used for other purposes
+        'ALLOWED': ['draft', '2i', 'queued'],  # all labels used by Verba, not the ones used for other purposes
+        'DRAFT': 'draft',
+        '2I': '2i',
+        'QUEUED': 'queued'
     },
     'ASSIGNEES': {
         'ALLOWED': ['marcofucci']  # all github users allowed by this Verba instance
-    }
+    },
 }
 
 AUTH_USER_MODEL = 'auth.models.VerbaUser'

--- a/verba/settings/testing.py
+++ b/verba/settings/testing.py
@@ -6,3 +6,4 @@ VERBA_CONFIG.update({
     'GITHUB_API_HOST': 'https://api.example.com',
     'REPO': 'test-owner/test-repo'
 })
+VERBA_CONFIG['ASSIGNEES']['ALLOWED'] = ['test-owner']

--- a/verba/templates/revision/include/form.html
+++ b/verba/templates/revision/include/form.html
@@ -1,0 +1,15 @@
+{% csrf_token %}
+{% if form.non_field_errors %}
+<div class="text-danger">{{ form.non_field_errors|join:", "|escape }}</div>
+{% endif %}
+
+{% for field in form.visible_fields %}
+<div class="form-group">
+  {% if field.errors %}
+    <div class="text-danger">{{ field.errors|join:", "|escape }}</div>
+  {% endif %}
+
+  {{ field.label_tag }}
+  {{ field }}
+</div>
+{% endfor %}

--- a/verba/templates/revision/list.html
+++ b/verba/templates/revision/list.html
@@ -2,7 +2,7 @@
 
 {% block title %}Revisions{% endblock %}
 {% block actions %}
-
+<a href="{% url 'revision:new' %}" class="btn btn-primary-outline">New</a>
 {% endblock %}
 
 {% block content %}

--- a/verba/templates/revision/new.html
+++ b/verba/templates/revision/new.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+
+{% block title %}New Revision{% endblock %}
+
+{% block content %}
+<div class="bd-callout">
+  Give the revision a short title so that you can identify it easily.
+</div>
+
+<form action="" method="post">
+  {% include "revision/include/form.html" %}
+
+  <button type="submit" class="btn btn-primary">Save</button>
+</form>
+{% endblock content %}


### PR DESCRIPTION
This allows a logged-in user to create a new revision
Behind the scenes the logic:
- creates a new branch with a specific name
- adds a empty file to the folder of the revision logs
- creates a new PR with label == 'draft' and assigned to the creator

The branch name is of type:
	`<namespace>|<slugified pr title>|<creator username>|<random string>`