### PR TITLE
List files of type manifest.json

### DIFF
--- a/verba/apps/github/tests/fixtures/file_contents.json
+++ b/verba/apps/github/tests/fixtures/file_contents.json
@@ -1,18 +1,18 @@
 {
     "type": "file",
-    "download_url": "https://raw.githubusercontent.com/test-owner/test-repo/test-branch/pages/index.json",
+    "download_url": "https://raw.githubusercontent.com/test-owner/test-repo/test-branch/pages/index/manifest.json",
     "content": "SW5kZXgKLS0tLS0KdGhpcyBpcyBhIHRlc3QK\n",
-    "url": "https://api.github.com/repos/test-owner/test-repo/contents/pages/index.json?ref=test-branch",
-    "html_url": "https://github.com/test-owner/test-repo/blob/test-branch/pages/index.json",
+    "url": "https://api.github.com/repos/test-owner/test-repo/contents/pages/index/manifest.json?ref=test-branch",
+    "html_url": "https://github.com/test-owner/test-repo/blob/test-branch/pages/index/manifest.json",
     "encoding": "base64",
     "size": 27,
     "git_url": "https://api.github.com/repos/test-owner/test-repo/git/blobs/516d891c230cd456bfeffac87e72aa344eacce76",
     "_links": {
         "git": "https://api.github.com/repos/test-owner/test-repo/git/blobs/516d891c230cd456bfeffac87e72aa344eacce76",
-        "self": "https://api.github.com/repos/test-owner/test-repo/contents/pages/index.json?ref=test-branch",
-        "html": "https://github.com/test-owner/test-repo/blob/test-branch/pages/index.json"
+        "self": "https://api.github.com/repos/test-owner/test-repo/contents/pages/index/manifest.json?ref=test-branch",
+        "html": "https://github.com/test-owner/test-repo/blob/test-branch/pages/index/manifest.json"
     },
-    "name": "index.json",
-    "path": "pages/index.json",
+    "name": "manifest.json",
+    "path": "pages/index/manifest.json",
     "sha": "89687e38c8d76a0759ad921d79194ebfcab5e6d6"
 }

--- a/verba/apps/github/tests/fixtures/git_tree.json
+++ b/verba/apps/github/tests/fixtures/git_tree.json
@@ -18,7 +18,7 @@
         },
         {
             "url": "https://api.github.com/repos/test-owner/test-repo/git/blobs/516d891c230cd456bfeffac87e72aa344eacce76",
-            "path": "index.json",
+            "path": "index/manifest.json",
             "size": 345,
             "sha": "516d891c230cd456bfeffac87e72aa344eacce76",
             "type": "blob",
@@ -26,7 +26,7 @@
         },
         {
             "url": "https://api.github.com/repos/test-owner/test-repo/git/blobs/a7e7a5bb6c71b5718d535a4140fb7326ea80bbc3",
-            "path": "stomach-ache.json",
+            "path": "stomach-ache/manifest.json",
             "size": 1393,
             "sha": "a7e7a5bb6c71b5718d535a4140fb7326ea80bbc3",
             "type": "blob",

--- a/verba/apps/github/tests/fixtures/new_file.json
+++ b/verba/apps/github/tests/fixtures/new_file.json
@@ -29,16 +29,16 @@
     "content": {
         "type": "file",
         "size": 12,
-        "path": "pages/index.json",
+        "path": "pages/index/manifest.json",
         "git_url": "https://api.github.com/repos/test-owner/test-repo/git/blobs/f0eec86f614944a81f87d879ebdc9a79aea0d7ea",
-        "html_url": "https://github.com/test-owner/test-repo/blob/test-branch/pages/index.json",
-        "name": "index.json",
-        "download_url": "https://raw.githubusercontent.com/test-owner/test-repo/test-branch/pages/index.json",
-        "url": "https://api.github.com/repos/test-owner/test-repo/contents/pages/index.json?ref=test-branch",
+        "html_url": "https://github.com/test-owner/test-repo/blob/test-branch/pages/index/manifest.json",
+        "name": "manifest.json",
+        "download_url": "https://raw.githubusercontent.com/test-owner/test-repo/test-branch/pages/index/manifest.json",
+        "url": "https://api.github.com/repos/test-owner/test-repo/contents/pages/index/manifest.json?ref=test-branch",
         "_links": {
-            "self": "https://api.github.com/repos/test-owner/test-repo/contents/pages/index.json?ref=test-branch",
+            "self": "https://api.github.com/repos/test-owner/test-repo/contents/pages/index/manifest.json?ref=test-branch",
             "git": "https://api.github.com/repos/test-owner/test-repo/git/blobs/f0eec86f614944a81f87d879ebdc9a79aea0d7ea",
-            "html": "https://github.com/test-owner/test-repo/blob/test-branch/pages/index.json"
+            "html": "https://github.com/test-owner/test-repo/blob/test-branch/pages/index/manifest.json"
         },
         "sha": "f0eec86f614944a81f87d879ebdc9a79aea0d7ea"
     }

--- a/verba/apps/github/tests/test_file.py
+++ b/verba/apps/github/tests/test_file.py
@@ -10,8 +10,8 @@ from github.tests.test_base import BaseGithubTestCase
 class BaseFileTestCase(BaseGithubTestCase):
     def setUp(self):
         super(BaseFileTestCase, self).setUp()
-        self.file_name = 'index.json'
-        self.path = 'pages/{}'.format(self.file_name)
+        self.file_name = 'manifest.json'
+        self.path = 'pages/index/{}'.format(self.file_name)
         self.branch_name = 'new-branch'
 
         self.file_content_github_url = self.get_github_api_repo_url('contents/{}'.format(self.path))
@@ -72,7 +72,7 @@ class CreateFileTestCase(BaseFileTestCase):
         self.assertRaises(
             InvalidResponseException,
             github.File.create,
-            self.TOKEN, path='pages/index.json', branch_name=self.branch_name,
+            self.TOKEN, path='pages/index/manifest.json', branch_name=self.branch_name,
             content='some content', message='some message'
         )
 

--- a/verba/apps/revision/constants.py
+++ b/verba/apps/revision/constants.py
@@ -2,3 +2,5 @@ BRANCH_PARTS_SEPARATOR = '|'
 
 REVISION_LOG_FILE_COMMIT_MSG = 'Create revision log file'
 REVISION_BODY_MSG = 'Content revision "{title}"'
+
+CONTENT_FILE_MANIFEST = 'manifest.json'

--- a/verba/apps/revision/models.py
+++ b/verba/apps/revision/models.py
@@ -7,24 +7,24 @@ from github.exceptions import NotFoundException as GithubNotFoundException
 from verba_settings import config
 
 from .utils import is_verba_branch, generate_verba_branch_name, get_verba_branch_name_info, is_content_file
-from .constants import REVISION_LOG_FILE_COMMIT_MSG, REVISION_BODY_MSG
+from .constants import REVISION_LOG_FILE_COMMIT_MSG, REVISION_BODY_MSG, CONTENT_FILE_MANIFEST
 from .exceptions import RevisionNotFoundException
 
 
 class RevisionFile(object):
     def __init__(self, _file, revision_id):
         assert _file.path.startswith(config.PATHS.CONTENT_FOLDER)
+        assert _file.path.endswith(CONTENT_FILE_MANIFEST)
 
         self.revision_id = revision_id
         self._file = _file
 
     @property
     def name(self):
-        return self._file.name
-
-    @property
-    def path(self):
-        return self._file.path[len(config.PATHS.CONTENT_FOLDER):]
+        local_path = self._file.path[len(config.PATHS.CONTENT_FOLDER):]
+        return local_path.replace(
+            '/{}'.format(CONTENT_FILE_MANIFEST), ''
+        )
 
 
 class Revision(object):

--- a/verba/apps/revision/models.py
+++ b/verba/apps/revision/models.py
@@ -20,7 +20,7 @@ class RevisionFile(object):
         self._file = _file
 
     @property
-    def name(self):
+    def path(self):
         local_path = self._file.path[len(config.PATHS.CONTENT_FOLDER):]
         return local_path.replace(
             '/{}'.format(CONTENT_FILE_MANIFEST), ''

--- a/verba/apps/revision/tests/test_models.py
+++ b/verba/apps/revision/tests/test_models.py
@@ -187,7 +187,7 @@ class RevisionTestCase(SimpleTestCase):
 
     def test_get_files(self):
         git_files = [
-            mock.MagicMock(path='{}test1/{}'.format(config.PATHS.CONTENT_FOLDER, CONTENT_FILE_MANIFEST)),
+            mock.MagicMock(path='{}some-path/test1/{}'.format(config.PATHS.CONTENT_FOLDER, CONTENT_FILE_MANIFEST)),
             mock.MagicMock(path='{}test2/manifest.txt'.format(config.PATHS.CONTENT_FOLDER)),
             mock.MagicMock(path='{}test3/{}'.format(config.PATHS.CONTENT_FOLDER, CONTENT_FILE_MANIFEST))
         ]
@@ -196,8 +196,8 @@ class RevisionTestCase(SimpleTestCase):
         rev_files = self.revision.get_files()
         self.assertEqual(len(rev_files), 2)
         self.assertEqual(
-            sorted([rev_file.name for rev_file in rev_files]),
-            ['test1', 'test3']
+            sorted([rev_file.path for rev_file in rev_files]),
+            ['some-path/test1', 'test3']
         )
 
 
@@ -205,14 +205,14 @@ class RevisionFileTestCase(SimpleTestCase):
     def setUp(self):
         super(RevisionFileTestCase, self).setUp()
         mocked_file = mock.MagicMock()
-        mocked_file.path = '{}test-page/{}'.format(
+        mocked_file.path = '{}some-path/test-page/{}'.format(
             config.PATHS.CONTENT_FOLDER, CONTENT_FILE_MANIFEST
         )
         self.revision_file = RevisionFile(
             _file=mocked_file, revision_id=1
         )
 
-    def test_name(self):
+    def test_path(self):
         self.assertEqual(
-            self.revision_file.name, 'test-page'
+            self.revision_file.path, 'some-path/test-page'
         )

--- a/verba/apps/revision/tests/test_models.py
+++ b/verba/apps/revision/tests/test_models.py
@@ -9,7 +9,7 @@ from github.exceptions import NotFoundException
 
 from revision.models import RevisionManager, Revision, RevisionFile
 from revision.utils import generate_verba_branch_name
-from revision.constants import REVISION_LOG_FILE_COMMIT_MSG, REVISION_BODY_MSG
+from revision.constants import REVISION_LOG_FILE_COMMIT_MSG, REVISION_BODY_MSG, CONTENT_FILE_MANIFEST
 from revision.exceptions import RevisionNotFoundException
 
 
@@ -187,17 +187,17 @@ class RevisionTestCase(SimpleTestCase):
 
     def test_get_files(self):
         git_files = [
-            mock.MagicMock(path='{}test1.json'.format(config.PATHS.CONTENT_FOLDER)),
-            mock.MagicMock(path='{}test2.txt'.format(config.PATHS.CONTENT_FOLDER)),
-            mock.MagicMock(path='{}test3.json'.format(config.PATHS.CONTENT_FOLDER))
+            mock.MagicMock(path='{}test1/{}'.format(config.PATHS.CONTENT_FOLDER, CONTENT_FILE_MANIFEST)),
+            mock.MagicMock(path='{}test2/manifest.txt'.format(config.PATHS.CONTENT_FOLDER)),
+            mock.MagicMock(path='{}test3/{}'.format(config.PATHS.CONTENT_FOLDER, CONTENT_FILE_MANIFEST))
         ]
         self.revision._pull.branch.get_dir_files.return_value = git_files
 
         rev_files = self.revision.get_files()
         self.assertEqual(len(rev_files), 2)
         self.assertEqual(
-            sorted([rev_file.path for rev_file in rev_files]),
-            ['test1.json', 'test3.json']
+            sorted([rev_file.name for rev_file in rev_files]),
+            ['test1', 'test3']
         )
 
 
@@ -205,18 +205,14 @@ class RevisionFileTestCase(SimpleTestCase):
     def setUp(self):
         super(RevisionFileTestCase, self).setUp()
         mocked_file = mock.MagicMock()
-        mocked_file.name = 'test name'
-        mocked_file.path = '{}test-path/subpath'.format(config.PATHS.CONTENT_FOLDER)
+        mocked_file.path = '{}test-page/{}'.format(
+            config.PATHS.CONTENT_FOLDER, CONTENT_FILE_MANIFEST
+        )
         self.revision_file = RevisionFile(
             _file=mocked_file, revision_id=1
         )
 
     def test_name(self):
         self.assertEqual(
-            self.revision_file.name, 'test name'
-        )
-
-    def test_path(self):
-        self.assertEqual(
-            self.revision_file.path, 'test-path/subpath'
+            self.revision_file.name, 'test-page'
         )

--- a/verba/apps/revision/tests/test_utils.py
+++ b/verba/apps/revision/tests/test_utils.py
@@ -100,7 +100,10 @@ class GetVerbaBranchNameInfo(SimpleTestCase):
 class IsContentFileTestCase(SimpleTestCase):
     def test_true(self):
         self.assertTrue(
-            is_content_file('some-path/{}'.format(CONTENT_FILE_MANIFEST.upper()))
+            is_content_file('some-file/{}'.format(CONTENT_FILE_MANIFEST.upper()))
+        )
+        self.assertTrue(
+            is_content_file('some-path/some-file/{}'.format(CONTENT_FILE_MANIFEST.upper()))
         )
 
     def test_false(self):

--- a/verba/apps/revision/tests/test_utils.py
+++ b/verba/apps/revision/tests/test_utils.py
@@ -4,7 +4,7 @@ from verba_settings import config
 
 from revision.utils import is_verba_branch, generate_verba_branch_name, get_verba_branch_name_info, \
     is_content_file
-from revision.constants import BRANCH_PARTS_SEPARATOR
+from revision.constants import BRANCH_PARTS_SEPARATOR, CONTENT_FILE_MANIFEST
 
 
 class IsVerbaBranchTestCase(SimpleTestCase):
@@ -100,15 +100,10 @@ class GetVerbaBranchNameInfo(SimpleTestCase):
 class IsContentFileTestCase(SimpleTestCase):
     def test_true(self):
         self.assertTrue(
-            is_content_file('some-name.json')
+            is_content_file('some-path/{}'.format(CONTENT_FILE_MANIFEST.upper()))
         )
 
-    def test_different_extension(self):
+    def test_false(self):
         self.assertFalse(
-            is_content_file('some-name.txt')
-        )
-
-    def test_without_extension(self):
-        self.assertFalse(
-            is_content_file('some-name')
+            is_content_file('some-path/something{}'.format(CONTENT_FILE_MANIFEST))
         )

--- a/verba/apps/revision/tests/test_views.py
+++ b/verba/apps/revision/tests/test_views.py
@@ -48,13 +48,16 @@ class NewRevisionTestCase(AuthTestCase):
         self.assertTrue(response.context['form'].errors)
 
     def test_success(self, MockedRevisionManager):  # noqa
+        mocked_manager = MockedRevisionManager()
+        mocked_manager.create.return_value = mock.MagicMock(id=1)
+
         self.login()
 
         title = 'test title'
         response = self.client.post(self.url, data={'title': title})
         self.assertEqual(response.status_code, 302)
 
-        MockedRevisionManager().create_assert_called_with(
+        mocked_manager.create.assert_called_with(
             title, self.get_user_data()['login']
         )
 

--- a/verba/apps/revision/utils.py
+++ b/verba/apps/revision/utils.py
@@ -3,7 +3,7 @@ from django.utils.crypto import get_random_string
 
 from verba_settings import config
 
-from .constants import BRANCH_PARTS_SEPARATOR
+from .constants import BRANCH_PARTS_SEPARATOR, CONTENT_FILE_MANIFEST
 
 
 def is_verba_branch(name):
@@ -42,9 +42,9 @@ def get_verba_branch_name_info(branch_name):
     return tuple(parts)
 
 
-def is_content_file(file_name):
+def is_content_file(path):
     """
-    Probably to improve. At the moment it only checks if the file has an md extension.
+    Returns True if file_name matches the CONTENT_FILE_MANIFEST naming convention
     """
-    parts = file_name.split('.')
-    return len(parts) > 1 and parts[-1].lower() == config.CONTENT_FILE_EXTENSION
+    file_name = path.split('/')[-1]
+    return file_name and file_name.lower() == CONTENT_FILE_MANIFEST

--- a/verba/apps/revision/views.py
+++ b/verba/apps/revision/views.py
@@ -52,7 +52,7 @@ class NewRevision(RevisionMixin, FormView):
         return super(NewRevision, self).form_valid(form)
 
     def get_success_url(self):
-        return reverse('revision:list')
+        return reverse('revision:detail-editor', kwargs={'revision_id': self.revision.id})
 
 
 class BaseRevisionDetail(RevisionDetailMixin, TemplateView):

--- a/verba/settings/base.py
+++ b/verba/settings/base.py
@@ -119,7 +119,6 @@ VERBA_CONFIG = {
     'GITHUB_HTTP_HOST': 'https://github.com',
     'GITHUB_API_HOST': 'https://api.github.com',
     'REPO': None,  # GitHub repo with content files to edit in format '<org>/<repo>'
-    'CONTENT_FILE_EXTENSION': 'json',
     'GITHUB_AUTH': {
         'CLIENT_ID': None,
         'CLIENT_SECRET': None,

--- a/verba/templates/revision/detail-editor.html
+++ b/verba/templates/revision/detail-editor.html
@@ -4,7 +4,7 @@
 <div class="col-sm-3">
   {% for rev_file in revision.get_files %}
   <div>
-    <a href="#">{{ rev_file.path }}</a>
+    <a href="#">{{ rev_file.name }}</a>
   </div>
   {% endfor %}
 </div>

--- a/verba/templates/revision/detail-editor.html
+++ b/verba/templates/revision/detail-editor.html
@@ -4,7 +4,7 @@
 <div class="col-sm-3">
   {% for rev_file in revision.get_files %}
   <div>
-    <a href="#">{{ rev_file.name }}</a>
+    <a href="#">{{ rev_file.path }}</a>
   </div>
   {% endfor %}
 </div>


### PR DESCRIPTION
Change content file formats.

**Old way**: content-name.json
**New way**: content-name/manifest.json

manifest.json includes content and metadata and the name of the folder represents the content name.
Additional content files (probably in markdown) will be in the local content folder and referenced from the manifest.